### PR TITLE
refactor: repository is renamed from namics to merkle

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# EditorConfig. Frontend. Default. Namics.
+# EditorConfig. Frontend. Default. Mekrle.
 # @see: http://EditorConfig.org
 # install a plugin to your editor: http://editorconfig.org/#download
 # mark: not all plugins supports the same EditorConfig properties

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# EditorConfig. Frontend. Default. Mekrle.
+# EditorConfig. Frontend. Default. Merkle.
 # @see: http://EditorConfig.org
 # install a plugin to your editor: http://editorconfig.org/#download
 # mark: not all plugins supports the same EditorConfig properties

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2018 Namics AG
+Copyright (c) 2015 Merkle Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ESLint config Namics
+# ESLint config
 
-[![Build Status](https://github.com/namics/eslint-config-namics/workflows/ci/badge.svg)](https://github.com/namics/eslint-config-namics/actions)
+[![Build Status](https://github.com/merkle-open/eslint-config/workflows/ci/badge.svg)](https://github.com/merkle-open/eslint-config/actions)
 [![npm](https://img.shields.io/npm/v/@namics/eslint-config.svg)](https://www.npmjs.com/package/@namics/eslint-config)
-[![Codestyle](https://img.shields.io/badge/codestyle-namics-green.svg)](https://github.com/namics/eslint-config-namics)
+[![Codestyle](https://img.shields.io/badge/codestyle-namics-green.svg)](https://github.com/merkle-open/eslint-config)
 
 ## Installation
 
@@ -116,6 +116,7 @@ then run `npm run lint`
 
 ## Thanks to
 
+* [Merkle.](https://www.merkleinc.com/)
 * [Namics.](https://www.namics.com/en/)
 * [ESLint](https://github.com/eslint/eslint) for ESLint and the documentation [eslint.org](http://eslint.org/)
 * [Walmart](https://github.com/walmartlabs) for sharing their config in [eslint-config-walmart](https://github.com/walmartlabs/eslint-config-walmart)
@@ -127,4 +128,4 @@ then run `npm run lint`
 
 ## Changelog
 
-Please see the [Releases](https://github.com/namics/eslint-config-namics/releases)
+Please see the [Releases](https://github.com/merkle-open/eslint-config/releases)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/merkle-open/eslint-config/workflows/ci/badge.svg)](https://github.com/merkle-open/eslint-config/actions)
 [![npm](https://img.shields.io/npm/v/@namics/eslint-config.svg)](https://www.npmjs.com/package/@namics/eslint-config)
-[![Codestyle](https://img.shields.io/badge/codestyle-namics-green.svg)](https://github.com/merkle-open/eslint-config)
+[![Codestyle](https://img.shields.io/badge/codestyle-merkle-green.svg)](https://github.com/merkle-open/eslint-config)
 
 ## Installation
 
@@ -16,7 +16,7 @@ $ npm install --save-dev eslint eslint-plugin-import @namics/eslint-config
 - `@namics/eslint-config/configurations/typescript-react` - typescript + react
 - `@namics/eslint-config/configurations/typescript-node` - typescript + node
 
-*package.json*
+_package.json_
 
 ```json
 {
@@ -26,7 +26,7 @@ $ npm install --save-dev eslint eslint-plugin-import @namics/eslint-config
 }
 ```
 
-*Enabling ESLint on TS files in VSCode*
+_Enabling ESLint on TS files in VSCode_
 
 You need to update the eslint.validate setting to:
 
@@ -84,6 +84,7 @@ module.exports = {
   "lint:js": "eslint ."
 },
 ```
+
 then run `npm run lint`
 
 ### Example usage in project tree
@@ -91,13 +92,13 @@ then run `npm run lint`
 - .eslintrc.js (es8-react)
 - .eslintignore
 - src
-    - app.jsx
+  - app.jsx
 - test
-    - .eslintrc.js (es8-node)
-    - index.js
+  - .eslintrc.js (es8-node)
+  - index.js
 - scripts
-    - .eslintrc.js (es6-node)
-    - index.js
+  - .eslintrc.js (es6-node)
+  - index.js
 
 ## Documentation
 
@@ -116,11 +117,11 @@ then run `npm run lint`
 
 ## Thanks to
 
-* [Merkle.](https://www.merkleinc.com/)
-* [Namics.](https://www.namics.com/en/)
-* [ESLint](https://github.com/eslint/eslint) for ESLint and the documentation [eslint.org](http://eslint.org/)
-* [Walmart](https://github.com/walmartlabs) for sharing their config in [eslint-config-walmart](https://github.com/walmartlabs/eslint-config-walmart)
-* [AirBnB](https://github.com/airbnb) for sharing their eslint config in [JavaScript Style Guide](https://github.com/airbnb/javascript)
+- [Merkle.](https://www.merkleinc.com/)
+- [Namics.](https://www.namics.com/en/)
+- [ESLint](https://github.com/eslint/eslint) for ESLint and the documentation [eslint.org](http://eslint.org/)
+- [Walmart](https://github.com/walmartlabs) for sharing their config in [eslint-config-walmart](https://github.com/walmartlabs/eslint-config-walmart)
+- [AirBnB](https://github.com/airbnb) for sharing their eslint config in [JavaScript Style Guide](https://github.com/airbnb/javascript)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -2,19 +2,19 @@
   "name": "@namics/eslint-config",
   "version": "9.0.5",
   "description": "Default configurations for eslint",
-  "author": "Namics AG",
+  "author": "Merkle Inc.",
   "contributors": [
-    "Ernst Ammann <ernst.ammann@namics.com>",
-    "Simon Mollweide <simon.mollweide@namics.com>"
+    "Ernst Ammann <ernst.ammann@emea.merkleinc.com>",
+    "Simon Mollweide"
   ],
   "license": "MIT",
   "private": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/namics/eslint-config-namics.git"
+    "url": "https://github.com/merkle-open/eslint-config.git"
   },
   "bugs": {
-    "url": "https://github.com/namics/eslint-config-namics/issues"
+    "url": "https://github.com/merkle-open/eslint-config/issues"
   },
   "main": "configurations/es6-browser.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "9.0.5",
   "description": "Default configurations for eslint",
   "author": "Merkle Inc.",
-  "contributors": [
-    "Ernst Ammann <ernst.ammann@emea.merkleinc.com>",
-    "Simon Mollweide"
-  ],
   "license": "MIT",
   "private": false,
   "repository": {

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -5,7 +5,7 @@ module.exports = {
 		// require trailing commas in multiline object literals
 		'comma-dangle': [2, 'always-multiline'],
 		// [13.07.2016] enabled
-		// [20.09.2016] always-multiline -> https://github.com/namics/eslint-config-namics/issues/1
+		// [20.09.2016] always-multiline -> https://github.com/merkle-open/eslint-config/issues/1
 
 		// disallow assignment in conditional expressions
 		'no-cond-assign': [2, 'always'],


### PR DESCRIPTION
Note: additional needed changes in regards to the renaming of the repository from `eslint-config-nacmics` to `eslint-config` are added in this pull request. Therefore this PR should be merged together with the renaming of the repository itself.